### PR TITLE
fix: stop auto-appending /v1 to API URL

### DIFF
--- a/src/llm_client.zsh
+++ b/src/llm_client.zsh
@@ -55,9 +55,6 @@ nlsh-make-api-request() {
     local payload=$1
     local url_base=${OPENAI_URL_BASE:-"https://openrouter.ai/api/v1"}
     local normalized_base=${url_base%/}
-    if [[ "$normalized_base" != */v1 ]]; then
-        normalized_base="$normalized_base/v1"
-    fi
     local endpoint="$normalized_base/chat/completions"
     local curl_cmd=(curl -s -S)
     


### PR DESCRIPTION
## Summary
- Remove the logic that automatically appends `/v1` to the API base URL
- Users can now specify the full API URL including version path

## Problem
The previous implementation forced `/v1` to be appended to URLs that didn't already end with it, breaking APIs like Perplexity that require `/v2`.

## Solution
Users should now specify the complete base URL:
- OpenRouter: `OPENAI_URL_BASE="https://openrouter.ai/api/v1"`
- Perplexity: `OPENAI_URL_BASE="https://api.perplexity.ai/v2"`

Closes #8